### PR TITLE
Fix double-tap zoom issue for iOS

### DIFF
--- a/OsmSharp.iOS.UI/MapView.cs
+++ b/OsmSharp.iOS.UI/MapView.cs
@@ -867,9 +867,13 @@ namespace OsmSharp.iOS.UI
 		{
 			get	{ return _mapZoom; }
 			set {
-                if (value > _mapMaxZoomLevel || value < _mapMinZoomLevel)
+                if (value > _mapMaxZoomLevel)
                 {
-                    _mapZoom = value;
+                    _mapZoom = MAX_ZOOM_LEVEL;
+                }
+                else if (value < _mapMinZoomLevel)
+                {
+                    _mapZoom = 0;
                 }
                 else
                 {


### PR DESCRIPTION
Double-tap on iOS caused the map to zoom to level 19 automatically due to wrong usage of System.Math.Max().

Also added some zoom level boundry checks to the setters of MapZoom, MapMaxZoomLevel and MapMinZoomLevel. This makes NormalizeZoom() redundant.
