### PR TITLE
ZoomToControls method of the MapView class (issue with Percentage)

### DIFF
--- a/OsmSharp.Android.UI/MapView.cs
+++ b/OsmSharp.Android.UI/MapView.cs
@@ -417,7 +417,7 @@ namespace OsmSharp.Android.UI
         {
             lock (_controls)
             {
-                this.ZoomToControls(_controls, 15);
+                this.ZoomToControls(_controls, percentage);
             }
         }
 


### PR DESCRIPTION
Percentage was hardcoded to 15 in this ZoomToControls method:
public void ZoomToControls(double percentage)