### PR TITLE
Proper dispose of MapViewSurface to prevent activity leak

### DIFF
--- a/OsmSharp.Android.UI/Surfaces/MapViewSurface.cs
+++ b/OsmSharp.Android.UI/Surfaces/MapViewSurface.cs
@@ -157,13 +157,13 @@ namespace OsmSharp.Android.UI
             // initialize the gesture detection.
             this.SetOnTouchListener(this);
             _scaleGestureDetector = new ScaleGestureDetector(
-                this.Context, this);
+                Application.Context, this);
             _rotateGestureDetector = new RotateGestureDetector(
-                this.Context, this);
+                Application.Context, this);
             _moveGestureDetector = new MoveGestureDetector(
-                this.Context, this);
+                Application.Context, this);
             _tagGestureDetector = new TapGestureDetector(
-                this.Context, this);
+                Application.Context, this);
 
             _makerLayer = new LayerPrimitives(
                 new WebMercator());
@@ -1255,6 +1255,11 @@ namespace OsmSharp.Android.UI
             {
                 this._map = null;
             }
+
+            this._scaleGestureDetector = null;
+            this._tagGestureDetector = null;
+            this._moveGestureDetector = null;
+            this._rotateGestureDetector = null;
         }
 
         private class MapViewControlZoomEvent


### PR DESCRIPTION
Activity which contains a MapView will be leaked even if properly disposing the MapView. Mono GC doesn't want to clean up the MapViewSurface because of referencing in the gesture detectors.

Activity leak was observed using Android StrictMode. I also tried the tarjan GC but same problem.

Solution seems to be to clear the reference to the gesture detectors in the Dispose of the MapViewSurface.