### PR TITLE
Single rendering thread

### DIFF
--- a/OsmSharp.UI/Map/Layers/LayerMBTile.cs
+++ b/OsmSharp.UI/Map/Layers/LayerMBTile.cs
@@ -160,6 +160,8 @@ namespace OsmSharp.UI.Map.Layers
                 // build the tile range.
                 var range = TileRange.CreateAroundBoundingBox(new GeoCoordinateBox(map.Projection.ToGeoCoordinates(viewBox.Min[0], viewBox.Min[1]),
                     map.Projection.ToGeoCoordinates(viewBox.Max[0], viewBox.Max[1])), zoomLevel);
+
+				OsmSharp.Logging.Log.TraceEvent ("LayerMBTile", OsmSharp.Logging.TraceEventType.Verbose, string.Format ("Requesting {0} tiles for view.", range.Count));
                 
                 // request all missing tiles.
                 lock (_connection)
@@ -170,8 +172,10 @@ namespace OsmSharp.UI.Map.Layers
                     foreach (var tile in range.EnumerateInCenterFirst())
                     {
                         Image2D value;
-                        if(_cache.TryPeek(tile, out value))
-                        { // tile is already in cache.
+						if(_cache.TryPeek(tile, out value))
+                        {
+							// Tile is already in cache. We used TryGet, and not TryPeek, to inform the cache
+							// that we intend to use the datum in question.
                             continue;
                         }
                         Tile invertTile = tile.InvertY();


### PR DESCRIPTION
I was having problems with MapViewSurface and iOS MapView failing to render when appropriate and it was difficult for me to reason about what it was doing so I reorganized the rendering into a rendering loop thread instead of launching multiple render threads which lock and block.

The UI element creates a single rendering thread which performs rendering based on whether or not the rendering is "dirty". TriggerRender now flags the render as "dirty", and the render thread flags it as non-dirty _before_ performing the render. If TriggerRender is called _during_ a render, than the flag will be set to true and another render will occur after the current has finished.

This solved bugs where the map would frequently fail to update, like in the attached screenshots.

Furthermore, LayerMBTile has been modified to make sure the LRUCache is informed about which tiles are going to be used for current view even if the tiles are already present in the cache and do not have to be loaded. This solves a condition where tiles which are needed are dropped during the load to make room for other tiles which are needed, even if the tile cache is large enough to accommodate the load.

![device-2015-11-23-134511](https://cloud.githubusercontent.com/assets/5166338/11366577/57ce160a-92ae-11e5-8663-0ed76d72a973.png)
![device-2015-11-24-103147](https://cloud.githubusercontent.com/assets/5166338/11366578/57fc1f32-92ae-11e5-9a93-cab56d8ee696.png)

