### PR TITLE
MapView updates

### DIFF
--- a/OsmSharp.UI/Map/Layers/LayerMBTile.cs
+++ b/OsmSharp.UI/Map/Layers/LayerMBTile.cs
@@ -172,7 +172,7 @@ namespace OsmSharp.UI.Map.Layers
                     foreach (var tile in range.EnumerateInCenterFirst())
                     {
                         Image2D value;
-						if(_cache.TryPeek(tile, out value))
+						if(_cache.TryGet(tile, out value))
                         {
 							// Tile is already in cache. We used TryGet, and not TryPeek, to inform the cache
 							// that we intend to use the datum in question.


### PR DESCRIPTION
If the pinch, pan and rotate gestures engage simultaneously than NotifyMovement is called multiple times per frame, and the unnecessary workload caues points of interest to visibly lag behind the user's fingers on some devices (like iPad 2).

There appears to be a fix in there where InvokeOnMainThread is used to call NotifyMovement later, but, InvokeOnMainThread does not work the same way as SwingUtilities.InvokeLater and other similar methods; the action is performed _synchronously_ and the caller must wait. (This can be observed by logging a warning if _triggeredNotifyMovement is false at the end of NotifyMovementByInvoke.)

I've replaced this solution. The new solution creates a CADisplayLink to call a method called OnPreRender before the painting of each frame. NotifyMovement now flips on a switch (_notifyMovementWanted) which affects the behaviour of OnPreRender. If _notifyMovementWanted is on at the start of OnPreRender, than it will be switched off, and then the notification will occur.

After this change, I no longer experience visible lag; the POIs rotate with my hand and are able to keep up.

Also: Fixed a mistake in a prior commit; LayerMBTile is supposed to use TryGet when checking for the presence of a wanted datum in the LRUCache.