### PR TITLE
Gesture recognizer configuration

### DIFF
--- a/OsmSharp.iOS.UI/MapView.cs
+++ b/OsmSharp.iOS.UI/MapView.cs
@@ -266,20 +266,21 @@ namespace OsmSharp.iOS.UI
 			else
 			{
 				var panGesture = new UIPanGestureRecognizer(Pan);
+				var pinchGesture = new UIPinchGestureRecognizer(Pinch);
+				var rotationGesture = new UIRotationGestureRecognizer(Rotate);
+
 				panGesture.ShouldRecognizeSimultaneously += (UIGestureRecognizer r, UIGestureRecognizer other) =>
 				{
-					return true;
+					return other != rotationGesture;
 				};
 				this.AddGestureRecognizer(panGesture);
 
-				var pinchGesture = new UIPinchGestureRecognizer(Pinch);
 				pinchGesture.ShouldRecognizeSimultaneously += (UIGestureRecognizer r, UIGestureRecognizer other) =>
 				{
 					return true;
 				};
 				this.AddGestureRecognizer(pinchGesture);
 
-				var rotationGesture = new UIRotationGestureRecognizer(Rotate);
 				rotationGesture.ShouldRecognizeSimultaneously += (UIGestureRecognizer r, UIGestureRecognizer other) =>
 				{
 					return true;


### PR DESCRIPTION
Map pan and rotate should not engage simultaneously because they clobber the map center. I've amended the gesture recognizers so that they will not engage simultaneously.