### PR TITLE
There exist scenarios where _mapZoomLevelBefore has no value. I have …

### DIFF
--- a/OsmSharp.iOS.UI/MapView.cs
+++ b/OsmSharp.iOS.UI/MapView.cs
@@ -660,7 +660,7 @@ namespace OsmSharp.iOS.UI
 				}
 				else
 				{
-					MapZoom = _mapZoomLevelBefore.Value;
+					MapZoom = _mapZoomLevelBefore.GetValueOrDefault (1.0f);
 
 					double zoomFactor = this.Map.Projection.ToZoomFactor(MapZoom);
 					zoomFactor = zoomFactor * pinch.Scale;


### PR DESCRIPTION
…added a default value.